### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/bindings/go/utils.go
+++ b/bindings/go/utils.go
@@ -48,6 +48,11 @@ func extractTarGz(tarGzPath, destPath string) error {
 			return fmt.Errorf("tar reading error: %v", err)
 		}
 
+		// Check for directory traversal
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("invalid file path in tar archive: %s", header.Name)
+		}
+
 		target := filepath.Join(destPath, header.Name)
 
 		switch header.Typeflag {


### PR DESCRIPTION
Fixes [https://github.com/amikos-tech/llamacpp-embedder/security/code-scanning/1](https://github.com/amikos-tech/llamacpp-embedder/security/code-scanning/1)

To fix the problem, we need to ensure that the `header.Name` does not contain any directory traversal elements (`..`) before using it to construct the `target` path. This can be achieved by checking if the `header.Name` contains `..` and skipping such entries if they do.

1. Add a check to ensure `header.Name` does not contain `..`.
2. If `header.Name` contains `..`, skip the current iteration and do not perform any file system operations for that entry.
3. This change should be made in the `extractTarGz` function in the file `bindings/go/utils.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
